### PR TITLE
CE-425 ParserUtil::sanitizeUrl() in Location::setUrl() adds unnecessa…

### DIFF
--- a/Entity/User.php
+++ b/Entity/User.php
@@ -11,6 +11,7 @@
 namespace CampaignChain\Location\FacebookBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use CampaignChain\CoreBundle\Util\ParserUtil;
 
 /**
  * @ORM\Entity
@@ -360,7 +361,7 @@ class User extends LocationBase
      */
     public function setProfileUrl($profileUrl)
     {
-        $this->profileUrl = $profileUrl;
+        $this->profileUrl = ParserUtil::sanitizeUrl($profileUrl);
 
         return $this;
     }
@@ -406,7 +407,7 @@ class User extends LocationBase
      */
     public function setCoverInfoUrl($coverInfoUrl)
     {
-        $this->coverInfoUrl = $coverInfoUrl;
+        $this->coverInfoUrl = ParserUtil::sanitizeUrl($coverInfoUrl);
 
         return $this;
     }


### PR DESCRIPTION
…ry trailing slash that causes e.g. GoToWebinar links to not work
