### PR TITLE
CampaignChain/campaignchain#174

### DIFF
--- a/Job/ReportFacebookPageMetrics.php
+++ b/Job/ReportFacebookPageMetrics.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * This file is part of the CampaignChain package.
+ *
+ * (c) CampaignChain, Inc. <info@campaignchain.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CampaignChain\Location\FacebookBundle\Job;
+
+use CampaignChain\CoreBundle\Entity\SchedulerReportLocation;
+use CampaignChain\CoreBundle\Job\JobReportInterface;
+use Doctrine\ORM\EntityManager;
+
+class ReportFacebookPageMetrics implements JobReportInterface
+{
+    const BUNDLE_NAME = 'campaignchain/location-facebook';
+    const METRIC_LIKES = 'Likes';
+
+    protected $em;
+    protected $container;
+
+    protected $message;
+
+    public function __construct(EntityManager $em, $container)
+    {
+        $this->em = $em;
+        $this->container = $container;
+    }
+
+    public function schedule($location, $facts = null)
+    {
+        $scheduler = new SchedulerReportLocation();
+        $scheduler->setLocation($location);
+        $scheduler->setInterval('1 hour');
+        $this->em->persist($scheduler);
+
+        $facts[self::METRIC_LIKES] = 0;
+
+        $factService = $this->container->get('campaignchain.core.fact');
+        $factService->addLocationFacts(self::BUNDLE_NAME, $location, $facts);
+    }
+
+    public function execute($locationId)
+    {
+        $client = $this->container->get('campaignchain.channel.facebook.rest.client');
+        $location = $this->em->getRepository('CampaignChainCoreBundle:Location')->find($locationId);
+        $connection = $client->connectByLocation($location);
+
+        if ($connection) {
+
+            // NOTE: this has already changed with FB API 2.6
+            $params = [
+                'fields' => 'likes',
+            ];
+            $response = $connection->api('/'.$location->getIdentifier(), 'GET', $params);
+            $likes = $response['likes'];
+
+            $connection->destroySession();
+        } else {
+            return self::STATUS_ERROR;
+        }
+
+        // Add report data.
+        $facts[self::METRIC_LIKES] = $likes;
+
+        $factService = $this->container->get('campaignchain.core.fact');
+        $factService->addLocationFacts(self::BUNDLE_NAME, $location, $facts);
+
+        $this->message = 'Added to report: likes = '.$likes.'.';
+
+        return self::STATUS_OK;
+    }
+
+    public function getMessage()
+    {
+        return $this->message;
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -11,3 +11,6 @@ parameters:
         module_identifier: "campaignchain-facebook-status"
 
 services:
+    campaignchain.job.report.location.facebook:
+        class: CampaignChain\Location\FacebookBundle\Job\ReportFacebookPageMetrics
+        arguments: [ @doctrine.orm.entity_manager, @service_container ]

--- a/campaignchain.yml
+++ b/campaignchain.yml
@@ -16,5 +16,12 @@ modules:
         hooks:
             default:
                 campaignchain-assignee: true
+        services:
+            report: campaignchain.job.report.location.facebook
+        metrics:
+            location:
+                - "Likes"
+
     campaignchain-facebook-status:
         display_name: Facebook status
+


### PR DESCRIPTION
CampaignChain/campaignchain#174
- trigger scheduler on creation of facebook page location
- trigger scheduler on creation of twitter user location
- add job for facebook location metrics
- add job for twitter location metrics
- add report module for location
- create template for location report
- update job command
- update scheduler command
- update installer
- update routes and services in core
- create fact and metric entities
- remove channel report stuff
- update fact service
- fix existing entities
- update campaignchain.yml configs
- create database migrations
- update amariki demo/test fixtures
- fix code style
